### PR TITLE
refactor: corrects operationIds in ewm service specs

### DIFF
--- a/ewm-main-service-spec.json
+++ b/ewm-main-service-spec.json
@@ -52,7 +52,7 @@
     "/admin/categories": {
       "post": {
         "description": "Обратите внимание: имя категории должно быть уникальным",
-        "operationId": "addCategory",
+        "operationId": "adminAddCategory",
         "requestBody": {
           "content": {
             "application/json": {
@@ -117,7 +117,7 @@
     "/admin/categories/{catId}": {
       "delete": {
         "description": "Обратите внимание: с категорией не должно быть связано ни одного события.",
-        "operationId": "deleteCategory",
+        "operationId": "adminRemoveCategory",
         "parameters": [
           {
             "description": "id категории",
@@ -174,7 +174,7 @@
       },
       "patch": {
         "description": "Обратите внимание: имя категории должно быть уникальным",
-        "operationId": "updateCategory",
+        "operationId": "adminUpdateCategory",
         "parameters": [
           {
             "description": "id категории",
@@ -250,7 +250,7 @@
     },
     "/admin/compilations": {
       "post": {
-        "operationId": "saveCompilation",
+        "operationId": "adminAddCompilation",
         "requestBody": {
           "content": {
             "application/json": {
@@ -314,7 +314,7 @@
     },
     "/admin/compilations/{compId}": {
       "delete": {
-        "operationId": "deleteCompilation",
+        "operationId": "adminRemoveCompilation",
         "parameters": [
           {
             "description": "id подборки",
@@ -354,7 +354,7 @@
         ]
       },
       "patch": {
-        "operationId": "updateCompilation",
+        "operationId": "adminUpdateCompilation",
         "parameters": [
           {
             "description": "id подборки",
@@ -415,7 +415,7 @@
     "/admin/events": {
       "get": {
         "description": "Эндпоинт возвращает полную информацию обо всех событиях подходящих под переданные условия\n\nВ случае, если по заданным фильтрам не найдено ни одного события, возвращает пустой список",
-        "operationId": "getEvents_2",
+        "operationId": "adminFindEvents",
         "parameters": [
           {
             "description": "список id пользователей, чьи события нужно найти",
@@ -536,7 +536,7 @@
     "/admin/events/{eventId}": {
       "patch": {
         "description": "Редактирование данных любого события администратором. Валидация данных не требуется.\nОбратите внимание:\n - дата начала изменяемого события должна быть не ранее чем за час от даты публикации. (Ожидается код ошибки 409)\n- событие можно публиковать, только если оно в состоянии ожидания публикации (Ожидается код ошибки 409)\n- событие можно отклонить, только если оно еще не опубликовано (Ожидается код ошибки 409)",
-        "operationId": "updateEvent_1",
+        "operationId": "adminUpdateEvent",
         "parameters": [
           {
             "description": "id события",
@@ -613,7 +613,7 @@
     "/admin/users": {
       "get": {
         "description": "Возвращает информацию обо всех пользователях (учитываются параметры ограничения выборки), либо о конкретных (учитываются указанные идентификаторы)\n\nВ случае, если по заданным фильтрам не найдено ни одного пользователя, возвращает пустой список",
-        "operationId": "getUsers",
+        "operationId": "adminGetUsers",
         "parameters": [
           {
             "description": "id пользователей",
@@ -688,7 +688,7 @@
         ]
       },
       "post": {
-        "operationId": "registerUser",
+        "operationId": "adminAddUser",
         "requestBody": {
           "content": {
             "application/json": {
@@ -752,7 +752,7 @@
     },
     "/admin/users/{userId}": {
       "delete": {
-        "operationId": "delete",
+        "operationId": "adminRemoveUser",
         "parameters": [
           {
             "description": "id пользователя",
@@ -1066,7 +1066,7 @@
     "/events": {
       "get": {
         "description": "Обратите внимание: \n- это публичный эндпоинт, соответственно в выдаче должны быть только опубликованные события\n- текстовый поиск (по аннотации и подробному описанию) должен быть без учета регистра букв\n- если в запросе не указан диапазон дат [rangeStart-rangeEnd], то нужно выгружать события, которые произойдут позже текущей даты и времени\n- информация о каждом событии должна включать в себя количество просмотров и количество уже одобренных заявок на участие\n- информацию о том, что по этому эндпоинту был осуществлен и обработан запрос, нужно сохранить в сервисе статистики\n\nВ случае, если по заданным фильтрам не найдено ни одного события, возвращает пустой список",
-        "operationId": "getEvents_1",
+        "operationId": "findEvents",
         "parameters": [
           {
             "description": "текст для поиска в содержимом аннотации и подробном описании события",
@@ -1203,7 +1203,7 @@
     "/events/{id}": {
       "get": {
         "description": "Обратите внимание:\n- событие должно быть опубликовано\n- информация о событии должна включать в себя количество просмотров и количество подтвержденных запросов\n- информацию о том, что по этому эндпоинту был осуществлен и обработан запрос, нужно сохранить в сервисе статистики\n\nВ случае, если события с заданным id не найдено, возвращает статус код 404",
-        "operationId": "getEvent_1",
+        "operationId": "getEvent",
         "parameters": [
           {
             "description": "id события",
@@ -1269,7 +1269,7 @@
     "/users/{userId}/events": {
       "get": {
         "description": "В случае, если по заданным фильтрам не найдено ни одного события, возвращает пустой список",
-        "operationId": "getEvents",
+        "operationId": "initiatorGetEvents",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1342,7 +1342,7 @@
       },
       "post": {
         "description": "Обратите внимание: дата и время на которые намечено событие не может быть раньше, чем через два часа от текущего момента",
-        "operationId": "addEvent",
+        "operationId": "initiatorAddEvent",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1419,7 +1419,7 @@
     "/users/{userId}/events/{eventId}": {
       "get": {
         "description": "В случае, если события с заданным id не найдено, возвращает статус код 404",
-        "operationId": "getEvent",
+        "operationId": "initiatorGetEvent",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1493,7 +1493,7 @@
       },
       "patch": {
         "description": "Обратите внимание:\n- изменить можно только отмененные события или события в состоянии ожидания модерации (Ожидается код ошибки 409)\n- дата и время на которые намечено событие не может быть раньше, чем через два часа от текущего момента (Ожидается код ошибки 409)\n",
-        "operationId": "updateEvent",
+        "operationId": "initiatorUpdateEvent",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1596,7 +1596,7 @@
     "/users/{userId}/events/{eventId}/requests": {
       "get": {
         "description": "В случае, если по заданным фильтрам не найдено ни одной заявки, возвращает пустой список",
-        "operationId": "getEventParticipants",
+        "operationId": "initiatorGetEventRequests",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1657,7 +1657,7 @@
       },
       "patch": {
         "description": "Обратите внимание:\n- если для события лимит заявок равен 0 или отключена пре-модерация заявок, то подтверждение заявок не требуется\n- нельзя подтвердить заявку, если уже достигнут лимит по заявкам на данное событие (Ожидается код ошибки 409)\n- статус можно изменить только у заявок, находящихся в состоянии ожидания (Ожидается код ошибки 409)\n- если при подтверждении данной заявки, лимит заявок для события исчерпан, то все неподтверждённые заявки необходимо отклонить",
-        "operationId": "changeRequestStatus",
+        "operationId": "initiatorChangeRequestStatus",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1760,7 +1760,7 @@
     "/users/{userId}/requests": {
       "get": {
         "description": "В случае, если по заданным фильтрам не найдено ни одной заявки, возвращает пустой список",
-        "operationId": "getUserRequests",
+        "operationId": "participantGetRequests",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1827,7 +1827,7 @@
       },
       "post": {
         "description": "Обратите внимание:\n- нельзя добавить повторный запрос  (Ожидается код ошибки 409)\n- инициатор события не может добавить запрос на участие в своём событии (Ожидается код ошибки 409)\n- нельзя участвовать в неопубликованном событии (Ожидается код ошибки 409)\n- если у события достигнут лимит запросов на участие - необходимо вернуть ошибку  (Ожидается код ошибки 409)\n- если для события отключена пре-модерация запросов на участие, то запрос должен автоматически перейти в состояние подтвержденного",
-        "operationId": "addParticipationRequest",
+        "operationId": "participantAddRequest",
         "parameters": [
           {
             "description": "id текущего пользователя",
@@ -1918,7 +1918,7 @@
     },
     "/users/{userId}/requests/{requestId}/cancel": {
       "patch": {
-        "operationId": "cancelRequest",
+        "operationId": "participantCancelRequest",
         "parameters": [
           {
             "description": "id текущего пользователя",


### PR DESCRIPTION
_Prerequisite: It is highly recommended to merge https://github.com/yandex-praktikum/java-explore-with-me/pull/22 changes, since generation via swagger-codegen-maven-plugin does not work correctly for original [ewm-main-service-spec.json](https://github.com/yandex-praktikum/java-explore-with-me/blob/main/ewm-main-service-spec.json) file._


In case of code generation via swagger-codegen-maven-plugin there are several problems with `operationId`s provided in [ewm-main-service-spec.json](https://github.com/yandex-praktikum/java-explore-with-me/blob/main/ewm-main-service-spec.json) file (see demo pom.xml in https://github.com/terekhovmv/java-explore-with-me-fixes/commit/da018e09eaa12ff28ff186a36edb0656ed7c30f1).
1. Some of `operationId`s contain numeric suffixes, and this suffixes appear in methods of generated `*Api` interfaces (`getEvents_2`, `getEvent_1`). Solution: remove suffixes at least.
1. There is no consistency in naming (`delete` / `deleteCompilation`, `registerUser` / `addEvent` / `saveCompilation`). Solution: provide consistent naming.
1. Since `*Api` interfaces are generated for top level endpoint components (`/users/*` => `UsersApi`) there are problems with identifying endpoint methods for different roles (e.g. `cancelRequest` and `changeRequestStatus` in the `UsersApi` interface). Solution: put the role as prefix in `operationId`s.
1. Since `operationId`s _must be unique among all operations described in your API_ (see https://swagger.io/docs/specification/paths-and-operations/), we should provide enough global descriptive names (`delete` or `getEvent_1` does not work).

Tabular view of changes proposed in this PR:
| Method  | Original operationId | Recommended operationId |
| ------------- | ------------- | ------------- |
|  **PUBLIC** |
| `GET    /categories` | `getCategories` | `getCategories` (no changes) |
| `GET    /categories/{catId}` | `getCategory` | `getCategory` (no changes) |
| `GET    /compilations` | `getCompilations` | `getCompilations` (no changes) |
| `GET    /compilations/{compId}` | `getCompilation` | `getCompilation` (no changes) |
| `GET    /events` | `getEvents_1` | `findEvents` |
| `GET    /events/{id}` | `getEvent_1` | `getEvent` |
|  **ADMIN** |
| `GET    /admin/users` | `getUsers` | `adminGetUsers` |
| `POST   /admin/users` | `registerUser` | `adminAddUser` |
| `DELETE /admin/users/{userId}` | `delete` | `adminRemoveUser` |
| `POST   /admin/categories` | `addCategory` | `adminAddCategory` |
| `DELETE /admin/categories/{catId}` | `deleteCategory` | `adminRemoveCategory` |
| `PATCH  /admin/categories/{catId}` | `updateCategory` | `adminUpdateCategory` |
| `GET    /admin/events` | `getEvents_2` | `adminFindEvents` |
| `PATCH  /admin/events/{eventId}` | `updateEvent_1` | `adminUpdateEvent` |
| `POST   /admin/compilations` | `saveCompilation` | `adminAddCompilation` |
| `DELETE /admin/compilations/{compId}` | `deleteCompilation` | `adminRemoveCompilation` |
| `PATCH  /admin/compilations/{compId}` | `updateCompilation` | `adminUpdateCompilation` |
|  **INITIATOR** |
| `GET    /users/{userId}/events` | `getEvents` | `initiatorGetEvents` |
| `GET    /users/{userId}/events/{eventId}` | `getEvents` | `initiatorGetEvent` |
| `POST   /users/{userId}/events` | `addEvent` | `initiatorAddEvent` |
| `PATCH  /users/{userId}/events/{eventId}` | `updateEvent` | `initiatorUpdateEvent` |
| `GET    /users/{userId}/events/{eventId}/requests` | `getEventParticipants` | `initiatorGetEventRequests` |
| `PATCH   /users/{userId}/events/{eventId}/requests` | `changeRequestStatus` | `initiatorChangeRequestStatus` |
|  **PARTICIPANT** |
| `GET    /users/{userId}/requests` | `getUserRequests` | `participantGetRequests` |
| `POST   /users/{userId}/requests` | `addParticipationRequest` | `participantAddRequest` |
| `PATCH  /users/{userId}/requests/{requestId}/cancel` | `cancelRequest` | `participantCancelRequest` |
